### PR TITLE
Update to datastore 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@google-cloud/datastore": "^0.4.0",
+    "@google-cloud/datastore": "0.6.0",
     "debug": "^2.2.0",
     "es6-promisify": "^5.0.0",
     "feathers-errors": "^2.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,20 +6,6 @@ const debug = makeDebug('feathers-datastore');
 
 const MAX_INDEX_SIZE = 1500;
 
-function promisify(obj, method) {
-  return (...args) => {
-    return new Promise((resolve, reject) => {
-      obj[method](...args, (err, result) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(result);
-        }
-      });
-    });
-  };
-}
-
 class Datastore {
   constructor(options = {}) {
     this.store = datastore({ projectId: options.projectId });
@@ -49,7 +35,8 @@ class Datastore {
 
   _get(id, params) {
     let key = this.makeKey(id, params);
-    return promisify(this.store, 'get')(key)
+    return this.store.get(key)
+      .then(([ entity ]) => entity)
       .then(this.entityToPlain(true))
       .then(entity => {
         if (!entity) {
@@ -80,7 +67,7 @@ class Datastore {
     // Convert entities to explicit format, to allow for indexing
     entities = this.makeExplicitEntity(entities, params);
 
-    return promisify(this.store, 'insert')(entities)
+    return this.store.insert(entities)
       .then(() => entities)
       .then(this.entityToPlain());
   }
@@ -93,7 +80,7 @@ class Datastore {
 
     entity = this.makeExplicitEntity(entity, params);
 
-    return promisify(this.store, method)(entity)
+    return this.store[method](entity)
       .then(() => entity)
       .then(this.entityToPlain())
       .catch(err => {
@@ -129,7 +116,7 @@ class Datastore {
 
         entities = this.makeExplicitEntity(entities, params);
 
-        return promisify(this.store, 'update')(entities)
+        return this.store.update(entities)
           .then(() => entities);
       })
       .then(this.entityToPlain());
@@ -209,7 +196,7 @@ class Datastore {
           keys = this.makeKey(results[ this.id ], params);
         }
 
-        return promisify(this.store, 'delete')(keys)
+        return this.store.delete(keys)
           .then(() => results);
       });
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,7 @@ function purge(done) {
         return;
       }
 
-      let keys = entities.map(({ key }) => key);
+      let keys = entities.map(service.Service.getKey);
       store.delete(keys, done);
     });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,11 +25,52 @@
     string-format-obj "^1.0.0"
     through2 "^2.0.0"
 
+"@google-cloud/common@^0.9.0":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-0.9.1.tgz#c72249589046fb4dd131b8ae7dbea88bb6bcf88c"
+  dependencies:
+    array-uniq "^1.0.2"
+    arrify "^1.0.0"
+    concat-stream "^1.5.0"
+    create-error-class "^3.0.2"
+    dot-prop "^2.4.0"
+    duplexify "^3.2.0"
+    ent "^2.2.0"
+    extend "^3.0.0"
+    google-auto-auth "^0.5.0"
+    google-proto-files "^0.8.0"
+    grpc "^1.0.0"
+    is "^3.0.1"
+    methmeth "^1.0.0"
+    modelo "^4.2.0"
+    request "^2.70.0"
+    retry-request "^1.3.0"
+    split-array-stream "^1.0.0"
+    stream-events "^1.0.1"
+    string-format-obj "^1.0.0"
+    through2 "^2.0.0"
+
 "@google-cloud/datastore@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/datastore/-/datastore-0.4.0.tgz#d0117a70b56c91c5564d405f8cb13760f90ef63b"
   dependencies:
     "@google-cloud/common" "^0.6.0"
+    arrify "^1.0.0"
+    concat-stream "^1.5.0"
+    create-error-class "^3.0.2"
+    extend "^3.0.0"
+    is "^3.0.1"
+    lodash.flatten "^4.2.0"
+    modelo "^4.2.0"
+    prop-assign "^1.0.0"
+    propprop "^0.3.0"
+    split-array-stream "^1.0.0"
+
+"@google-cloud/datastore@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/datastore/-/datastore-0.6.0.tgz#ffaf78ba24efb086315044beb944d818c05bd724"
+  dependencies:
+    "@google-cloud/common" "^0.9.0"
     arrify "^1.0.0"
     concat-stream "^1.5.0"
     create-error-class "^3.0.2"
@@ -146,7 +187,7 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.0-rc.5, async@^2.0.1:
+async@^2.0.0-rc.5, async@^2.0.1, async@^2.1.2:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
   dependencies:
@@ -1403,7 +1444,7 @@ globals@^9.0.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
 
-google-auth-library@^0.9.6:
+google-auth-library@^0.9.10, google-auth-library@^0.9.6:
   version "0.9.10"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-0.9.10.tgz#4993dc07bb4834b8ca0350213a6873a32c6051b9"
   dependencies:
@@ -1420,6 +1461,15 @@ google-auto-auth@^0.2.4:
   dependencies:
     google-auth-library "^0.9.6"
     object-assign "^3.0.0"
+
+google-auto-auth@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/google-auto-auth/-/google-auto-auth-0.5.2.tgz#4c9f38574e69fb55a3c516ab0415e9fa33e67602"
+  dependencies:
+    async "^2.1.2"
+    google-auth-library "^0.9.10"
+    object-assign "^3.0.0"
+    request "^2.79.0"
 
 google-p12-pem@^0.1.0:
   version "0.1.0"
@@ -2369,7 +2419,7 @@ request-promise@^4.0.0:
     request-promise-core "1.1.1"
     stealthy-require "^1.0.0"
 
-request@^2.69.0, request@^2.70.0, request@^2.72.0, request@^2.75.0:
+request@^2.69.0, request@^2.70.0, request@^2.72.0, request@^2.75.0, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:


### PR DESCRIPTION
Updates to datastore 0.6.0.

Changes:
 - [x] Handle get / find returning flat objects rather than of the form { key, data }
 - [x] Fetch keys using datastore.KEY symbol on retrieved entities, but at entity.key on creating entities
 - [x] Utilise built in promises

Paves the way for using forked 0.6.0 which supports deep exclusions of property indexing