### PR TITLE
Fixed 2 bugs + Added possibility to use credentials object for auth

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,9 +54,11 @@ class Datastore {
 
   _create(data, params = {}) {
     let entities = [],
-        key;
+        key,
+        wasArray;
 
-    data = Array.isArray(data) ? data : [data];
+    wasArray = Array.isArray(data);
+    data = wasArray ? data : [data];
 
     data.map(item => {
       if (item.hasOwnProperty(this.id)) {
@@ -70,8 +72,8 @@ class Datastore {
       });
     });
 
-    // unbox if only 1 entity is inserted
-    if (data.length === 1) {
+    // unbox if data param was an object
+    if (!wasArray) {
       entities = entities[0];
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,7 @@ class Datastore {
     }
 
     if (Array.isArray(entity)) {
-      return entity.map(this.makeExplicitEntity, this);
+      return entity.map((e) => this.makeExplicitEntity(e, options), this);
     }
 
     return {

--- a/src/index.js
+++ b/src/index.js
@@ -53,20 +53,26 @@ class Datastore {
   }
 
   _create(data, params = {}) {
-    let entities,
+    let entities = [],
         key;
 
-    if (data.hasOwnProperty(this.id)) {
-      key = this.makeKey(data[this.id], params);
-    } else {
-      key = this.makeKey(undefined, params);
-    }
+    data = Array.isArray(data) ? data : [data];
 
-    entities = { key, data };
+    data.map(item => {
+      if (item.hasOwnProperty(this.id)) {
+        key = this.makeKey(item[this.id], params);
+      } else {
+        key = this.makeKey(undefined, params);
+      }
+      entities.push({
+        key,
+        data: item,
+      });
+    });
 
-    // Normalize
-    if (Array.isArray(data)) {
-      entities = data.map(data => ({ key, data }));
+    // unbox if only 1 entity is inserted
+    if (data.length === 1) {
+      entities = entities[0];
     }
 
     // Convert entities to explicit format, to allow for indexing

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,12 @@ const MAX_INDEX_SIZE = 1500;
 
 class Datastore {
   constructor(options = {}) {
-    this.store = datastore({ projectId: options.projectId });
+    const datastoreOpt = { projectId: options.projectId };
+
+    if (options.credentials) {
+      datastoreOpt.credentials = options.credentials;
+    }
+    this.store = datastore(datastoreOpt);
 
     this.id = options.id || 'id';
     this.kind = options.kind;


### PR DESCRIPTION
Hi,

I am using the `credentials` config object option to authenticate against google cloud, [as specified here](https://googlecloudplatform.github.io/google-cloud-node/#/docs/datastore/1.0.0/guides/authentication). 

This pr just propagates options.credentials to the datastore constructor when it is truthy, allowing to use this way of authenticating.