### PR TITLE
Use upstream @google-cloud/datastore dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@google-cloud/datastore": "https://github.com/bedeoverend/google-cloud-node/releases/download/datastore-v0.6.2.rc1/datastore.tar.gz",
+    "@google-cloud/datastore": "^1.4.0",
     "debug": "^2.2.0",
     "feathers-errors": "^2.4.0",
     "lodash": "^4.17.4"
@@ -66,8 +66,8 @@
     "feathers-rest": "^1.5.0",
     "feathers-service-tests": "^0.8.1",
     "jshint": "^2.9.3",
-    "mocha": "^2.5.3",
-    "nsp": "^2.6.1",
+    "mocha": "^5.2.0",
+    "nsp": "^3.2.1",
     "rimraf": "^2.5.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ class Datastore {
     this.store = datastore(datastoreOpt);
 
     this.id = options.id || 'id';
-    this.kind = options.kind;
+    this.kind = options.kind || options.name;
     this.events = options.events;
     this.autoIndex = options.autoIndex || false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ class Datastore {
     this.kind = options.kind || options.name;
     this.events = options.events;
     this.autoIndex = options.autoIndex || false;
+    this.namespace = options.namespace || undefined;
 
     // NOTE: This isn't nice, but it's the only way to give internal methods full
     //  unrestricted (no hooks) access to all methods
@@ -149,7 +150,7 @@ class Datastore {
     params.query = params.query || {};
 
     let { ancestor, namespace, kind = this.kind, $select, ...query } = params.query,
-        dsQuery = this.store.createQuery(namespace, kind),
+        dsQuery = this.store.createQuery(namespace || this.namespace, kind),
         retainOnlySelected = identity,
         filterOutAncestor = identity,
         filters;
@@ -250,8 +251,8 @@ class Datastore {
       key = this.store.key([ this.kind, id ]);
     }
 
-    if (query.namespace) {
-      key.namespace = query.namespace;
+    if (query.namespace || this.namespace) {
+      key.namespace = query.namespace || this.namespace;
     }
 
     return key;


### PR DESCRIPTION
Since [this issue](https://github.com/GoogleCloudPlatform/google-cloud-node/issues/1916) has been resolved, I've updated the package.json to use the upstream `@google-cloud/datastore`, resolving issue #8 . 

Also resolved 8 vulnerabilities by upgrading `mocha` and `nsp`.